### PR TITLE
QueryService: fix exit on windows

### DIFF
--- a/tinyoscquery/queryservice.py
+++ b/tinyoscquery/queryservice.py
@@ -32,7 +32,7 @@ class OSCQueryService(object):
         self._startOSCQueryService()
         self._advertiseOSCService()
         self.http_server = OSCQueryHTTPServer(self.root_node, self.host_info, ('', self.httpPort), OSCQueryHTTPHandler)
-        self.http_thread = threading.Thread(target=self._startHTTPServer)
+        self.http_thread = threading.Thread(target=self._startHTTPServer, daemon=True)
         self.http_thread.start()
 
     def __del__(self):


### PR DESCRIPTION
On Windows, when Python exits, it waits for all non-daemon threads to finish execution before it completely shuts down. This can lead to a situation where if these threads are relying on resources that are being cleaned up during the interpreter shutdown it cause a deadlock.